### PR TITLE
HELLODATA-4021 fix(sftpgo-sidecar): key updateUser on getUsername() not getEmail()

### DIFF
--- a/hello-data-sidecars/hello-data-sidecar-sftpgo/src/main/java/ch/bedag/dap/hellodata/sidecars/sftpgo/service/SftpGoService.java
+++ b/hello-data-sidecars/hello-data-sidecar-sftpgo/src/main/java/ch/bedag/dap/hellodata/sidecars/sftpgo/service/SftpGoService.java
@@ -76,8 +76,8 @@ public class SftpGoService {
     public void updateUser(User user) {
         refreshToken();
         UsersApi usersApi = new UsersApi(sftpGoApiClient);
-        usersApi.updateUser(user.getEmail(), user, 1).block();
-        log.info("User {} updated", user.getEmail());
+        usersApi.updateUser(user.getUsername(), user, 1).block();
+        log.info("User {} updated", user.getUsername());
     }
 
     public void enableUser(String username) {


### PR DESCRIPTION
## Problem
`SftpGoService.updateUser()` passed `user.getEmail()` as the sftpgo API `username` path parameter. In sftpgo the identifier is `username` (the email-string set as the key); `email` is a separate, optional/nullable attribute. For users whose sftpgo record has an empty email (e.g. `admin@` and `*-admin@` service accounts), `getEmail()` is null and the generated client throws:

```
Missing the required parameter 'username' when calling updateUser
```

so their context-role update fails and they don't get their data-domain S3 folders/groups. `enableUser`/`disableUser` already correctly use the `username` parameter — only `updateUser` used `getEmail()`.

## Fix
Use `user.getUsername()` (always populated, never null) as the path parameter and in the log line.

## Impact
Users with an empty email field now sync correctly; users with an email set are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)