### PR TITLE
HELLODATA-4022 docs(pom): correct Spring Boot/Cloud 4.1.x compatibility comments

### DIFF
--- a/hello-data-commons/hello-data-spring-boot-starter-parent/pom.xml
+++ b/hello-data-commons/hello-data-spring-boot-starter-parent/pom.xml
@@ -36,7 +36,7 @@
         <modelmapper.version>3.2.6</modelmapper.version>
         <push-docker-image-phase>post-integration-test</push-docker-image-phase>
         <rest-assured.version>6.0.0</rest-assured.version>
-        <!-- Boot 4.0.x to stay compatible with Spring Cloud 2025.1.x (Oakwood); no Cloud train targets Boot 4.1.x yet -->
+        <!-- Boot 4.1.x is supported by Spring Cloud 2025.1.2+ (Oakwood); keep Boot and Cloud versions in lockstep per the compatibility matrix -->
         <spring-boot.version>4.1.0</spring-boot.version>
         <!-- CVE-2026-42584 / BDSA-2026-9440: remove once Spring Boot ships Netty >= 4.2.13.Final -->
         <netty.version>4.2.15.Final</netty.version>
@@ -46,7 +46,7 @@
         <bouncycastle.version>1.84</bouncycastle.version>
         <!-- CVE-2026-42198 / BDSA-2026-8637: remove once Spring Boot ships postgresql >= 42.7.11 -->
         <postgresql.version>42.7.11</postgresql.version>
-        <!-- spring-cloud 2025.0.x targets Boot 3.5.x; 2025.1.x targets Boot 4.0.x -->
+        <!-- spring-cloud 2025.0.x targets Boot 3.5.x; 2025.1.0/.1 target Boot 4.0.x; 2025.1.2+ adds Boot 4.1.x support -->
         <spring-cloud.version>2025.1.2</spring-cloud.version>
         <spring-ws-test.version>5.0.2</spring-ws-test.version>
         <springdoc.version>3.0.3</springdoc.version>


### PR DESCRIPTION
Spring Cloud 2025.1.2 [introduces compatibility for Spring Boot 4.1.0](https://spring.io/blog/2026/06/11/spring-cloud-2025-1-2-aka-oakwood-has-been-released/). After the Boot 4.0.7 → 4.1.0 and Cloud 2025.1.0 → 2025.1.2 bump (#427), the pin comments in the starter-parent pom claiming `2025.1.x targets Boot 4.0.x` / `no Cloud train targets Boot 4.1.x yet` were stale. This corrects both comments to match the compatibility matrix. Comment-only change, no functional/dependency impact.