### PR TITLE
HELLODATA-4053 fix(security): sanitize Quill rich-text HTML with DOMPurify (mitigate GHSA-v3m3-f69x-jf25)

### DIFF
--- a/hello-data-portal/hello-data-portal-ui/package.json
+++ b/hello-data-portal/hello-data-portal-ui/package.json
@@ -43,6 +43,7 @@
     "angular-auth-oidc-client": "^21.0.0",
     "angular-build-info": "^2.0.1",
     "axios": "^1.13.5",
+    "dompurify": "^3.4.13",
     "ngx-matomo-client": "^9.0.0",
     "ngx-pipes": "^3.2.2",
     "pdfmake": "^0.3.7",

--- a/hello-data-portal/hello-data-portal-ui/src/app/pages/admin/announcements-management/announcements-management.component.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/pages/admin/announcements-management/announcements-management.component.ts
@@ -53,6 +53,7 @@ import {DeleteAnnouncementPopupComponent} from './delete-announcement-popup/dele
 import {TranslocoPipe} from '@jsverse/transloco';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {ICON_REGISTRY} from '../../../shared/icons';
+import {sanitizeRichText} from '../../../shared/utils/sanitize-html';
 
 @Component({
   selector: 'app-announcements-management',
@@ -102,7 +103,7 @@ export class AnnouncementsManagementComponent extends BaseComponent {
 
   getMessage(announcement: Announcement, selectedLanguage: any): SafeHtml {
     const message = this.findAnnouncementMessage(announcement, selectedLanguage.code) || '';
-    return this.sanitizer.bypassSecurityTrustHtml(message);
+    return this.sanitizer.bypassSecurityTrustHtml(sanitizeRichText(message));
   }
 
   private findAnnouncementMessage(announcement: Announcement, code: string | null | undefined): string | undefined {
@@ -121,7 +122,7 @@ export class AnnouncementsManagementComponent extends BaseComponent {
     return Object.entries(announcement.messages).map(([locale, message]) => ({
       locale,
       displayLocale: locale.split('_')[0].toUpperCase(),
-      message: this.sanitizer.bypassSecurityTrustHtml(message || '')
+      message: this.sanitizer.bypassSecurityTrustHtml(sanitizeRichText(message || ''))
     }));
   }
 }

--- a/hello-data-portal/hello-data-portal-ui/src/app/pages/admin/faq-management/faq-list.component.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/pages/admin/faq-management/faq-list.component.ts
@@ -49,6 +49,7 @@ import {TranslocoPipe} from '@jsverse/transloco';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {TranslateService} from "../../../shared/services/translate.service";
 import {ICON_REGISTRY} from '../../../shared/icons';
+import {sanitizeRichText} from '../../../shared/utils/sanitize-html';
 
 @Component({
   selector: 'app-faq-list',
@@ -139,7 +140,7 @@ export class FaqListComponent extends BaseComponent implements OnInit {
       locale,
       displayLocale: locale.split('_')[0].toUpperCase(),
       title: msg.title || '',
-      message: this.sanitizer.bypassSecurityTrustHtml(msg.message || '')
+      message: this.sanitizer.bypassSecurityTrustHtml(sanitizeRichText(msg.message || ''))
     }));
   }
 }

--- a/hello-data-portal/hello-data-portal-ui/src/app/pages/home/faq/faq.component.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/pages/home/faq/faq.component.ts
@@ -41,6 +41,7 @@ import {TranslocoPipe} from '@jsverse/transloco';
 import {Tooltip} from 'primeng/tooltip';
 import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {ICON_REGISTRY} from '../../../shared/icons';
+import {sanitizeRichText} from '../../../shared/utils/sanitize-html';
 
 @Component({
   selector: 'app-faq',
@@ -83,9 +84,9 @@ export class FaqComponent implements OnInit {
     const message = this.findMessage(faq, selectedLanguage)?.message;
     if (!message) {
       const fallback = '<p>' + this.translateService.translate('@Translation not available, fallback to default', {default: defaultLanguage.slice(0, 2)?.toUpperCase()}) + '</p>' + (this.findMessage(faq, defaultLanguage)?.message || '');
-      return this.sanitizer.bypassSecurityTrustHtml(fallback);
+      return this.sanitizer.bypassSecurityTrustHtml(sanitizeRichText(fallback));
     }
-    return this.sanitizer.bypassSecurityTrustHtml(message);
+    return this.sanitizer.bypassSecurityTrustHtml(sanitizeRichText(message));
   }
 
   /**

--- a/hello-data-portal/hello-data-portal-ui/src/app/pages/published-announcements/published-announcements.component.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/pages/published-announcements/published-announcements.component.ts
@@ -19,6 +19,7 @@ import {TranslocoPipe} from "@jsverse/transloco";
 
 import {Card} from 'primeng/card';
 import {ICON_REGISTRY} from '../../shared/icons';
+import {sanitizeRichText} from '../../shared/utils/sanitize-html';
 
 @Component({
   providers: [DialogService],
@@ -49,9 +50,9 @@ export class PublishedAnnouncementsComponent implements OnInit {
     const message = this.findMessage(announcement, selectedLanguage);
     if (!message || message.trim() === '') {
       const fallback = this.findMessage(announcement, defaultLanguage);
-      return this.translateService.translate('@Translation not available, fallback to default', {default: defaultLanguage.slice(0, 2)?.toUpperCase()}) + '\n' + (fallback ?? '');
+      return this.translateService.translate('@Translation not available, fallback to default', {default: defaultLanguage.slice(0, 2)?.toUpperCase()}) + '\n' + sanitizeRichText(fallback ?? '');
     }
-    return message;
+    return sanitizeRichText(message);
   }
 
   private findMessage(announcement: Announcement, code: string | null | undefined): string | undefined {

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/components/published-announcement/published-announcements-popup/published-announcements-popup.component.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/components/published-announcement/published-announcements-popup/published-announcements-popup.component.ts
@@ -16,6 +16,7 @@ import {TranslocoPipe} from "@jsverse/transloco";
 import {Checkbox} from "primeng/checkbox";
 import {DynamicDialogRef} from "primeng/dynamicdialog";
 import {ICON_REGISTRY} from '../../../icons';
+import {sanitizeRichText} from '../../../utils/sanitize-html';
 
 @Component({
   template: `
@@ -84,9 +85,9 @@ export class PublishedAnnouncementsPopupComponent implements OnDestroy {
     if (!message || message.trim() === '') {
       const fallback = this.findMessage(announcement, defaultLanguage);
       const defaultDisplay = defaultLanguage ? defaultLanguage.slice(0, 2)?.toUpperCase() : '??';
-      return this.translateService.translate('@Translation not available, fallback to default', {default: defaultDisplay}) + '\n' + (fallback ?? '');
+      return this.translateService.translate('@Translation not available, fallback to default', {default: defaultDisplay}) + '\n' + sanitizeRichText(fallback ?? '');
     }
-    return message;
+    return sanitizeRichText(message);
   }
 
   private findMessage(announcement: Announcement, code: string | null | undefined): string | undefined {

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/utils/sanitize-html.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/utils/sanitize-html.ts
@@ -25,30 +25,19 @@
 /// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ///
 
-import { Pipe, PipeTransform, inject } from '@angular/core';
-import {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl} from '@angular/platform-browser';
-import {sanitizeRichText} from '../utils/sanitize-html';
+import DOMPurify from 'dompurify';
 
-@Pipe({ name: 'safe' })
-export class SafePipe implements PipeTransform {
-  private sanitizer = inject(DomSanitizer);
-
-
-  public transform(value: string, type: string): SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
-    switch (type) {
-      case 'html':
-        return this.sanitizer.bypassSecurityTrustHtml(sanitizeRichText(value));
-      case 'style':
-        return this.sanitizer.bypassSecurityTrustStyle(value);
-      case 'script':
-        return this.sanitizer.bypassSecurityTrustScript(value);
-      case 'url':
-        return this.sanitizer.bypassSecurityTrustUrl(value);
-      case 'resourceUrl':
-        return this.sanitizer.bypassSecurityTrustResourceUrl(value);
-      default:
-        throw new Error(`Invalid safe type specified: ${type}`);
-    }
-  }
-
+/**
+ * Sanitizes rich-text HTML (e.g. Quill/p-editor output for FAQ and announcement
+ * messages) before it is rendered as trusted markup — either via
+ * DomSanitizer.bypassSecurityTrustHtml / [innerHTML], or fed back into a
+ * read-only Quill editor.
+ *
+ * This neutralizes stored XSS payloads (scripts, event-handler attributes,
+ * javascript: URLs, ...) while keeping the safe formatting tags the editor
+ * produces. It is the app-side remediation for GHSA-v3m3-f69x-jf25 (Quill XSS
+ * via HTML export), which has no upstream patched release.
+ */
+export function sanitizeRichText(html: string): string {
+  return DOMPurify.sanitize(html ?? '', { USE_PROFILES: { html: true } });
 }

--- a/hello-data-portal/hello-data-portal-ui/yarn.lock
+++ b/hello-data-portal/hello-data-portal-ui/yarn.lock
@@ -5773,6 +5773,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
@@ -7895,6 +7902,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dompurify@npm:^3.4.13":
+  version: 3.4.13
+  resolution: "dompurify@npm:3.4.13"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/9c2a1a71e1a1d8b77953db7a39ffc935ef4ed4f10fe40770232128c2cbfd4c3dc677d3d7bae51eb24cc52d9ff3548612dc540ecb4343e89b26e809d2be2e0cfe
+  languageName: node
+  linkType: hard
+
 "domutils@npm:^3.2.2":
   version: 3.2.2
   resolution: "domutils@npm:3.2.2"
@@ -9075,6 +9094,7 @@ __metadata:
     angular-build-info: "npm:^2.0.1"
     angular-eslint: "npm:^21.0.0"
     axios: "npm:^1.13.5"
+    dompurify: "npm:^3.4.13"
     eslint: "npm:^10.0.0"
     jest: "npm:^30.2.0"
     jest-environment-jsdom: "npm:^30.2.0"


### PR DESCRIPTION
quill 2.0.3 (GHSA-v3m3-f69x-jf25 — XSS via HTML export, low) has **no patched release**, so it can't be fixed by upgrade. FAQ and announcement messages authored in the Quill editor were rendered as fully trusted HTML (`bypassSecurityTrustHtml` / `[innerHTML]`, and fed back into read-only `p-editor` instances), so Angular's sanitizer never ran on them.

## Change
- Add **DOMPurify** (3.4.13) and a shared `sanitizeRichText()` helper (`shared/utils/sanitize-html.ts`).
- Route all trusted rich-text through it before rendering — neutralizes stored XSS while keeping safe formatting.

Covered render paths:
- FAQ view (`faq.component.ts`)
- Announcements management (`announcements-management.component.ts`, ×2)
- FAQ list (`faq-list.component.ts`)
- Published announcements page + popup (read-only `p-editor`)
- Shared `safe` pipe `html` case (defense-in-depth)

## Notes
- Validated: my changed files typecheck clean; the authoritative build runs via the `fix/*` mirror branch.
- Dependabot alert #97 will not auto-close (quill stays 2.0.3); it will be dismissed as *tolerable_risk / mitigated* once this merges.