### PR TITLE
HELLODATA-4022 fix(renovate): update stale Spring Boot/Cloud pins to Boot 4.1.0 baseline

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,17 +54,17 @@
       "enabled": false
     },
     {
-      "description": "Pin spring-boot to 4.0.x until a Spring Cloud train targets Boot 4.1.x",
+      "description": "Pin spring-boot to 4.1.x (supported by Spring Cloud 2025.1.2+); raise once a Spring Cloud train targets Boot 4.2.x",
       "matchManagers": [
         "maven"
       ],
       "matchPackageNames": [
         "org.springframework.boot:spring-boot-dependencies"
       ],
-      "allowedVersions": "<4.1.0"
+      "allowedVersions": "<4.2.0"
     },
     {
-      "description": "Keep spring-cloud on Oakwood (2025.1.x) which targets Spring Boot 4.0.x",
+      "description": "Keep spring-cloud on Oakwood (2025.1.x), which supports Spring Boot 4.0.x-4.1.x; raise once moving to the next train",
       "matchManagers": [
         "maven"
       ],


### PR DESCRIPTION
Config-only follow-up to #427/#458. The renovate pins still described `Boot 4.0.x` and blocked 4.1.x, contradicting the merged Spring Boot 4.1.0 / Spring Cloud 2025.1.2 state.

- `org.springframework.boot:spring-boot-dependencies`: `allowedVersions` `<4.1.0` → **`<4.2.0`** (allow 4.1.x, hold 4.2.x until a Spring Cloud train targets it).
- `org.springframework.cloud:spring-cloud-dependencies`: kept at `<2025.2.0` (Oakwood 2025.1.x); description corrected to note Boot 4.0.x–4.1.x support.

Validated as well-formed JSON. No build depends on `renovate.json`.