### PR TITLE
Filter unpublished versions from dashboard comment history

### DIFF
--- a/hello-data-portal/hello-data-portal-api/src/main/java/ch/bedag/dap/hellodata/portal/dashboard_comment/service/DashboardCommentService.java
+++ b/hello-data-portal/hello-data-portal-api/src/main/java/ch/bedag/dap/hellodata/portal/dashboard_comment/service/DashboardCommentService.java
@@ -369,18 +369,39 @@ public class DashboardCommentService {
     }
 
     /**
-     * Create a copy of the comment showing the last published version, or null if none exists.
+     * Create a redacted copy of the comment showing the last published version, or null if none exists.
+     * <p>
+     * Reaching this method already means the caller is not entitled to the comment's current,
+     * unpublished state (see {@link #handleDraftVisibility} / {@link #handleReviewOrDeclinedVisibility}),
+     * so the history is filtered as well: rewinding {@code activeVersion} alone would still ship every
+     * unpublished {@code text}, {@code editedBy} and {@code declineReason} to the client.
      */
     private DashboardCommentDto showLastPublishedVersion(DashboardCommentDto comment) {
         DashboardCommentVersionDto lastPublishedVersion = findLastPublishedVersion(comment);
-        if (lastPublishedVersion != null) {
-            return comment.toBuilder()
-                    .activeVersion(lastPublishedVersion.getVersion())
-                    .pointerUrl(lastPublishedVersion.getPointerUrl())
-                    .tags(lastPublishedVersion.getTags() != null ? lastPublishedVersion.getTags() : Collections.emptyList())
-                    .build();
+        if (lastPublishedVersion == null) {
+            return null;
         }
-        return null;
+        return comment.toBuilder()
+                .activeVersion(lastPublishedVersion.getVersion())
+                .pointerUrl(lastPublishedVersion.getPointerUrl())
+                .tags(lastPublishedVersion.getTags() != null ? lastPublishedVersion.getTags() : Collections.emptyList())
+                .history(publishedHistoryUpToVersion(comment.getHistory(), lastPublishedVersion.getVersion()))
+                .build();
+    }
+
+    /**
+     * The versions a caller may see when they are not entitled to the comment's current state: the
+     * published ones, up to and including the version they are being steered at.
+     */
+    private List<DashboardCommentVersionDto> publishedHistoryUpToVersion(List<DashboardCommentVersionDto> history,
+                                                                         int lastPublishedVersion) {
+        if (history == null) {
+            return Collections.emptyList();
+        }
+        return history.stream()
+                .filter(v -> v.getStatus() == DashboardCommentStatus.PUBLISHED)
+                .filter(v -> v.getVersion() <= lastPublishedVersion)
+                .toList();
     }
 
     /**
@@ -1219,6 +1240,11 @@ public class DashboardCommentService {
                 (userFullName != null && userFullName.equals(activeVersion.getEditedBy()));
     }
 
+    /**
+     * Domain-view counterpart of {@link #showLastPublishedVersion}. Mutating the DTO in place is safe
+     * here: {@link #toDomainDashboardCommentDto} builds a fresh instance, over a fresh history list,
+     * per request.
+     */
     private DomainDashboardCommentDto fallbackToLastPublishedVersion(DomainDashboardCommentDto comment) {
         DashboardCommentVersionDto lastPublished = findLastPublishedVersionInDomainDashboardComment(comment);
         if (lastPublished == null) {
@@ -1227,6 +1253,7 @@ public class DashboardCommentService {
         comment.setActiveVersion(lastPublished.getVersion());
         comment.setPointerUrl(lastPublished.getPointerUrl());
         comment.setTags(lastPublished.getTags() != null ? lastPublished.getTags() : Collections.emptyList());
+        comment.setHistory(publishedHistoryUpToVersion(comment.getHistory(), lastPublished.getVersion()));
         return comment;
     }
 

--- a/hello-data-portal/hello-data-portal-api/src/test/java/ch/bedag/dap/hellodata/portal/dashboard_comment/service/DashboardCommentUnpublishedTextLeakTest.java
+++ b/hello-data-portal/hello-data-portal-api/src/test/java/ch/bedag/dap/hellodata/portal/dashboard_comment/service/DashboardCommentUnpublishedTextLeakTest.java
@@ -1,0 +1,327 @@
+package ch.bedag.dap.hellodata.portal.dashboard_comment.service;
+
+import ch.bedag.dap.hellodata.commons.metainfomodel.service.MetaInfoResourceService;
+import ch.bedag.dap.hellodata.commons.security.SecurityUtils;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.data.DashboardCommentDto;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.data.DashboardCommentStatus;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.data.DashboardCommentVersionDto;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.data.DomainDashboardCommentDto;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.entity.DashboardCommentEntity;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.entity.DashboardCommentPermissionEntity;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.entity.DashboardCommentVersionEntity;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.mapper.DashboardCommentMapper;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.repository.DashboardCommentPermissionRepository;
+import ch.bedag.dap.hellodata.portal.dashboard_comment.repository.DashboardCommentRepository;
+import ch.bedag.dap.hellodata.portalcommon.user.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.Connection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Reproduces the redaction gap in {@link DashboardCommentService#getComments}: when the active
+ * version of a comment is DRAFT / READY_FOR_REVIEW / DECLINED and the caller has neither write nor
+ * review permission, {@code showLastPublishedVersion(...)} only rewinds the {@code activeVersion}
+ * pointer (plus pointerUrl/tags). The DTO's {@code history} list — which carries the full {@code text}
+ * of every version, plus {@code editedBy} / {@code editedByEmail} / {@code declineReason} — is copied
+ * through {@code toBuilder()} untouched and is serialized straight to the HTTP client.
+ * <p>
+ * Uses the real {@link DashboardCommentMapper} so the DTO under assertion is exactly what the
+ * controller returns.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DashboardCommentUnpublishedTextLeakTest {
+
+    private static final String CONTEXT_KEY = "dd_one";
+    private static final int DASHBOARD_ID = 123;
+
+    private static final String AUTHOR_EMAIL = "author@example.org";
+    private static final String AUTHOR_NAME = "Ann Author";
+    private static final String READER_EMAIL = "reader@example.org";
+    private static final String READER_NAME = "Rob Reader";
+
+    private static final String PUBLISHED_TEXT = "This is the published, approved comment.";
+    private static final String SECRET_DRAFT_TEXT = "INTERNAL DRAFT: the figures for Q3 are wrong, do not circulate.";
+    private static final String SECRET_DECLINE_REASON = "Rejected: contains unreleased headcount numbers.";
+
+    @Mock
+    private DashboardCommentRepository commentRepository;
+    @Mock
+    private DashboardCommentPermissionRepository commentPermissionRepository;
+    @Mock
+    private MetaInfoResourceService metaInfoResourceService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private DashboardCommentNotificationService notificationService;
+    @Mock
+    private DashboardCommentDwhSyncService dwhSyncService;
+    @Mock
+    private Connection connection;
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private DashboardCommentService commentService;
+
+    @BeforeEach
+    void setUp() {
+        commentService = new DashboardCommentService(commentRepository, commentPermissionRepository,
+                new DashboardCommentMapper(), metaInfoResourceService, userRepository,
+                notificationService, dwhSyncService, connection, objectMapper);
+
+        // No UserEntity -> shouldFilterByDashboardAccess() is false, so the RBAC dashboard filter is
+        // out of the picture and only the comment-status redaction under test remains.
+        when(userRepository.findUserEntityByEmailIgnoreCase(anyString())).thenReturn(Optional.empty());
+    }
+
+    private static DashboardCommentVersionEntity version(int number, DashboardCommentStatus status,
+                                                         String text, String editedBy, String declineReason) {
+        return DashboardCommentVersionEntity.builder()
+                .version(number)
+                .text(text)
+                .status(status)
+                .editedDate(1_700_000_000_000L + number)
+                .editedBy(editedBy)
+                .editedByEmail(AUTHOR_EMAIL)
+                .declineReason(declineReason)
+                .build();
+    }
+
+    /**
+     * A comment that was published (v1) and has since been re-opened for editing, which is exactly what
+     * {@code cloneCommentForEdit} produces: a new DRAFT version becomes the active one while the
+     * published version stays in history.
+     */
+    private DashboardCommentEntity publishedThenRedraftedComment(DashboardCommentStatus activeStatus,
+                                                                 String declineReason) {
+        DashboardCommentEntity comment = DashboardCommentEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .dashboardId(DASHBOARD_ID)
+                .dashboardUrl("https://superset.example.org/superset/dashboard/123/")
+                .contextKey(CONTEXT_KEY)
+                .author(AUTHOR_NAME)
+                .authorEmail(AUTHOR_EMAIL)
+                .createdDate(1_700_000_000_000L)
+                .activeVersion(2)
+                .hasActiveDraft(true)
+                .build();
+        comment.addVersion(version(1, DashboardCommentStatus.PUBLISHED, PUBLISHED_TEXT, AUTHOR_NAME, null));
+        comment.addVersion(version(2, activeStatus, SECRET_DRAFT_TEXT, AUTHOR_NAME, declineReason));
+        return comment;
+    }
+
+    private void stubStore(DashboardCommentEntity comment) {
+        when(commentRepository.findByContextKeyAndDashboardIdOrderByCreatedDateAsc(CONTEXT_KEY, DASHBOARD_ID))
+                .thenReturn(List.of(comment));
+    }
+
+    private void stubCaller(MockedStatic<SecurityUtils> securityUtils, String email, String fullName,
+                            boolean write, boolean review) {
+        UUID userId = UUID.randomUUID();
+        securityUtils.when(SecurityUtils::getCurrentUserEmail).thenReturn(email);
+        securityUtils.when(SecurityUtils::getCurrentUserFullName).thenReturn(fullName);
+        securityUtils.when(SecurityUtils::getCurrentUserId).thenReturn(userId);
+        securityUtils.when(SecurityUtils::isSuperuser).thenReturn(false);
+
+        DashboardCommentPermissionEntity perm = new DashboardCommentPermissionEntity();
+        perm.setReadComments(true);
+        perm.setWriteComments(write);
+        perm.setReviewComments(review);
+        when(commentPermissionRepository.findByUserIdAndContextKey(any(UUID.class), any(String.class)))
+                .thenReturn(Optional.of(perm));
+    }
+
+    private static List<String> textsInHistory(DashboardCommentDto dto) {
+        return dto.getHistory().stream().map(DashboardCommentVersionDto::getText).toList();
+    }
+
+    /**
+     * Read-only caller, active version is an unpublished DRAFT.
+     * Expected: only the published text reaches the caller. Actual: the draft text ships in history.
+     */
+    @Test
+    void readOnlyUserMustNotReceiveTheTextOfAnUnpublishedDraft() {
+        stubStore(publishedThenRedraftedComment(DashboardCommentStatus.DRAFT, null));
+
+        List<DashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, READER_EMAIL, READER_NAME, false, false);
+            result = commentService.getComments(CONTEXT_KEY, DASHBOARD_ID, false);
+        }
+
+        assertThat(result).hasSize(1);
+        DashboardCommentDto dto = result.get(0);
+
+        // The pointer is rewound correctly -- this part of the redaction works.
+        assertThat(dto.getActiveVersion())
+                .as("the caller should be steered at the last published version")
+                .isEqualTo(1);
+
+        // ...but the payload still carries the unpublished text.
+        assertThat(textsInHistory(dto))
+                .as("a read-only caller must not receive the text of an unpublished draft version")
+                .containsExactly(PUBLISHED_TEXT);
+    }
+
+    /**
+     * Same shape with a DECLINED active version: the decline reason is reviewer-internal and leaks too.
+     */
+    @Test
+    void readOnlyUserMustNotReceiveTheDeclineReasonOfADeclinedVersion() {
+        stubStore(publishedThenRedraftedComment(DashboardCommentStatus.DECLINED, SECRET_DECLINE_REASON));
+
+        List<DashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, READER_EMAIL, READER_NAME, false, false);
+            result = commentService.getComments(CONTEXT_KEY, DASHBOARD_ID, false);
+        }
+
+        assertThat(result).hasSize(1);
+        DashboardCommentDto dto = result.get(0);
+
+        assertThat(dto.getHistory())
+                .as("a read-only caller must not receive the reviewer's decline reason")
+                .noneMatch(v -> SECRET_DECLINE_REASON.equals(v.getDeclineReason()));
+    }
+
+    /**
+     * Control: a reviewer is entitled to a READY_FOR_REVIEW version and legitimately gets it, active
+     * pointer and all. Confirms the fixture really does carry an unpublished v2 and that the tests
+     * above differ from this one only in the caller's permissions.
+     */
+    @Test
+    void reviewerLegitimatelyReceivesTheVersionAwaitingReview() {
+        stubStore(publishedThenRedraftedComment(DashboardCommentStatus.READY_FOR_REVIEW, null));
+
+        List<DashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, "reviewer@example.org", "Rita Reviewer", true, true);
+            result = commentService.getComments(CONTEXT_KEY, DASHBOARD_ID, false);
+        }
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActiveVersion()).isEqualTo(2);
+        assertThat(textsInHistory(result.get(0))).contains(SECRET_DRAFT_TEXT);
+    }
+
+    /**
+     * Second control, and the sharpest framing of the defect: the same READY_FOR_REVIEW version that
+     * the reviewer above is entitled to is withheld from a read-only caller by the activeVersion
+     * rewind -- and shipped to them anyway inside history.
+     */
+    @Test
+    void readOnlyUserMustNotReceiveTheTextOfAVersionAwaitingReview() {
+        stubStore(publishedThenRedraftedComment(DashboardCommentStatus.READY_FOR_REVIEW, null));
+
+        List<DashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, READER_EMAIL, READER_NAME, false, false);
+            result = commentService.getComments(CONTEXT_KEY, DASHBOARD_ID, false);
+        }
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActiveVersion()).isEqualTo(1);
+        assertThat(textsInHistory(result.get(0)))
+                .as("a read-only caller must not receive the text of a version still awaiting review")
+                .containsExactly(PUBLISHED_TEXT);
+    }
+
+    /**
+     * The domain-wide view has the same defect through {@code fallbackToLastPublishedVersion}, and it is
+     * the wider exposure: one GET returns every dashboard's comments in the data domain at once.
+     */
+    @Test
+    void readOnlyUserMustNotReceiveUnpublishedTextInTheDomainView() {
+        DashboardCommentEntity comment = publishedThenRedraftedComment(DashboardCommentStatus.DRAFT, null);
+        when(commentRepository.findByContextKeyOrderByCreatedDateAsc(CONTEXT_KEY)).thenReturn(List.of(comment));
+
+        List<DomainDashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, READER_EMAIL, READER_NAME, false, false);
+            result = commentService.getCommentsForDomain(CONTEXT_KEY, false);
+        }
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActiveVersion())
+                .as("the caller should be steered at the last published version")
+                .isEqualTo(1);
+        assertThat(textsInHistory(result.get(0)))
+                .as("the domain view must not carry the text of an unpublished draft either")
+                .containsExactly(PUBLISHED_TEXT);
+    }
+
+    /**
+     * Control, and a guard against over-pruning: redaction must hide the unpublished versions, not
+     * collapse the history down to the single last published one. A comment published twice before
+     * being re-drafted still owes the read-only caller both published versions -- that is what the UI
+     * renders in the version-history table.
+     */
+    @Test
+    void readOnlyUserStillReceivesEveryPublishedVersionInHistory() {
+        DashboardCommentEntity comment = DashboardCommentEntity.builder()
+                .id(UUID.randomUUID().toString())
+                .dashboardId(DASHBOARD_ID)
+                .contextKey(CONTEXT_KEY)
+                .author(AUTHOR_NAME)
+                .authorEmail(AUTHOR_EMAIL)
+                .createdDate(1_700_000_000_000L)
+                .activeVersion(3)
+                .hasActiveDraft(true)
+                .build();
+        comment.addVersion(version(1, DashboardCommentStatus.PUBLISHED, "First published wording.", AUTHOR_NAME, null));
+        comment.addVersion(version(2, DashboardCommentStatus.PUBLISHED, "Second published wording.", AUTHOR_NAME, null));
+        comment.addVersion(version(3, DashboardCommentStatus.DRAFT, SECRET_DRAFT_TEXT, AUTHOR_NAME, null));
+        stubStore(comment);
+
+        List<DashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, READER_EMAIL, READER_NAME, false, false);
+            result = commentService.getComments(CONTEXT_KEY, DASHBOARD_ID, false);
+        }
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActiveVersion()).isEqualTo(2);
+        assertThat(textsInHistory(result.get(0)))
+                .as("redaction must drop only the unpublished versions, not the earlier published ones")
+                .containsExactly("First published wording.", "Second published wording.");
+    }
+
+    /**
+     * Control pinning the ownership rule: it lives in {@code handleDraftVisibility} (hasWrite &amp;&amp;
+     * isOwnDraft), one level above the redaction, so the author of a draft never reaches
+     * {@code showLastPublishedVersion} and keeps seeing their own work in full.
+     */
+    @Test
+    void authorWithWritePermissionStillSeesTheirOwnDraftInFull() {
+        stubStore(publishedThenRedraftedComment(DashboardCommentStatus.DRAFT, null));
+
+        List<DashboardCommentDto> result;
+        try (MockedStatic<SecurityUtils> securityUtils = mockStatic(SecurityUtils.class)) {
+            stubCaller(securityUtils, AUTHOR_EMAIL, AUTHOR_NAME, true, false);
+            result = commentService.getComments(CONTEXT_KEY, DASHBOARD_ID, false);
+        }
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActiveVersion())
+                .as("the author keeps their own draft as the active version")
+                .isEqualTo(2);
+        assertThat(textsInHistory(result.get(0))).containsExactly(PUBLISHED_TEXT, SECRET_DRAFT_TEXT);
+    }
+}


### PR DESCRIPTION
Hi @wieczorslawo ,

I ran into a small consistency issue while looking at the comment history endpoints. It’s low severity and not urgent, so I’m opening it as a normal PR rather than an advisory. Happy to move it to a private one instead if you’d prefer.

**What happens**

A user with only read access to a dashboard's comments can end up seeing another user's unpublished draft text, and a reviewer's decline reason, even though neither is visible anywhere in the portal UI.

It only shows up once a comment has more than one version, for example a published comment that gets edited afterwards. A brand new comment that was never published has no earlier version to fall back to, so nothing leaks there.

**Why**

Two code paths rewind `activeVersion` to the last published version when the caller isn't entitled to see the current one:

- `showLastPublishedVersion(...)`, used by `getComments`
  (`GET /dashboards/{contextKey}/{dashboardId}/comments`)
- `fallbackToLastPublishedVersion(...)`, used by `getCommentsForDomain`
  (`GET /dashboards/domain/{contextKey}`)

Both update the pointer correctly, but neither filters `history`, so the response still contains every version, including unpublished ones with their full `text`, `editedBy` and `declineReason`.

The frontend already filters this correctly (`dashboard-comment-utils.service.ts`, `getAllVersions` with `canViewMetadata = false`, which keeps only `PUBLISHED`). The gap is that the backend never applied the same rule, so anything that reads the API directly could still receive the unfiltered history.

**Before / after**

Same request, same user (`test-lesend`, read-only comment permission on this domain, no write or review permissions), before and after the fix:

<img width="744" height="503" alt="01-ohne-fix-commentsdashboard" src="https://github.com/user-attachments/assets/bf2a01ae-5113-4391-91a7-2d7e9f9b633a" />

<img width="767" height="469" alt="01-mit-fix-commentsdashboard" src="https://github.com/user-attachments/assets/545f48b6-844f-4f08-b65c-e78c0fc10e75" />


**Fix**

Added a private helper, `publishedHistoryUpToVersion(...)`,which is called from both of the methods above. It filters `history` to the published versions up to the effective visible version.

It deliberately does not touch the permission guards in `handleDraftVisibility` / `handleReviewOrDeclinedVisibility`. Those are correct, and authorship is already resolved there, so an author editing their own draft keeps seeing it in full. The bug was downstream of them.

Three new tests in `DashboardCommentUnpublishedTextLeakTest`, covering both routes, plus a guard against over-filtering: a reader must still receive every published version, not just the last one.

Thanks for taking a look! 🙂🙌