### PR TITLE
HELLODATA-4100 fix(jupyterhub-sidecar): shared-role temp users with dependency-free DROP USER

### DIFF
--- a/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/config/props/HellodataJupyterhubProperties.java
+++ b/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/config/props/HellodataJupyterhubProperties.java
@@ -16,4 +16,16 @@ public class HellodataJupyterhubProperties {
     private String dwhUrl;
     private String dwhDriverClassName;
     private List<String> dwhTempUserSchemas;
+    /**
+     * Shared group role that owns everything temporary users create and holds all their privileges.
+     * Temporary users are only login credentials that are members of this role, so they can be dropped
+     * with a plain DROP USER. PostgreSQL roles are cluster-global, so in a cluster shared by several data
+     * domains this name must be unique per data domain (e.g. include the DWH database name).
+     */
+    private String dwhSharedRole;
+    /**
+     * Schema, owned via the shared role, where temporary users create shared read-write tables. Objects
+     * there are owned by the shared role, so any temporary user (all of them admins) can manage them.
+     */
+    private String dwhSharedSchema;
 }

--- a/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/DwhSharedRoleInitializer.java
+++ b/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/DwhSharedRoleInitializer.java
@@ -1,0 +1,30 @@
+package ch.bedag.dap.hellodata.jupyterhub.sidecar.service.user;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provisions the shared DWH group role once the application is up. If the DWH is unreachable at startup the
+ * error is only logged - the shared role is re-ensured on the first temporary user creation - so a temporarily
+ * unavailable DWH never prevents the sidecar from starting.
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class DwhSharedRoleInitializer implements ApplicationRunner {
+
+    private final TemporaryUserService temporaryUserService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            temporaryUserService.ensureSharedRole();
+            log.info("Ensured DWH shared role for temporary users");
+        } catch (Exception e) {
+            log.error("Could not ensure DWH shared role at startup; it will be retried on first temporary user creation", e);
+        }
+    }
+}

--- a/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/TemporaryUserService.java
+++ b/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/TemporaryUserService.java
@@ -4,6 +4,7 @@ import ch.bedag.dap.hellodata.jupyterhub.sidecar.config.props.HellodataJupyterhu
 import ch.bedag.dap.hellodata.jupyterhub.sidecar.service.user.dto.TemporaryUserResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -16,61 +17,127 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Manages the temporary DWH users handed out to JupyterHub notebooks.
+ * <p>
+ * Access is modelled through a single shared group role (see {@link #ensureSharedRole()}): every temporary
+ * user is a member of that role and runs each session as it, so all privileges and all objects the users
+ * create belong to the shared role, never to the individual user. This keeps the notebook workspace shared
+ * between users (they are all admins and may manage each other's tables) and, crucially, lets an expired user
+ * be removed with a plain {@code DROP USER} - it owns nothing and holds no direct grants that would block it.
+ */
 @Log4j2
 @Service
 @RequiredArgsConstructor
 public class TemporaryUserService {
 
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     private final JdbcTemplate dwhJdbcTemplate;
     private final HellodataJupyterhubProperties hellodataProperties;
 
+    // Not @Transactional on purpose: in PostgreSQL a failed statement aborts the whole transaction,
+    // so one un-droppable role would otherwise block the cleanup of every other expired user.
     @Scheduled(cron = "0 0 0 * * ?") // Runs at midnight every day
-    @Transactional
     public void cleanupExpiredUsers() {
-        LocalDateTime now = LocalDateTime.now();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-        String findExpiredUsersSql = "SELECT usename FROM pg_catalog.pg_user WHERE valuntil < '" + now.format(formatter) + "' AND usename LIKE 'temp_user_%'";
+        String findExpiredUsersSql = "SELECT usename FROM pg_catalog.pg_user WHERE valuntil < '"
+                + LocalDateTime.now().format(TIMESTAMP_FORMATTER) + "' AND usename LIKE 'temp_user_%'";
         List<String> expiredUsernames = dwhJdbcTemplate.queryForList(findExpiredUsersSql, String.class); //NOSONAR
 
         for (String username : expiredUsernames) {
-            String dropUserSql = "DROP USER IF EXISTS " + username;
-            dwhJdbcTemplate.execute(dropUserSql); //NOSONAR
-            log.info("Dropped expired user: {}", username);
+            dropExpiredUser(username);
+        }
+    }
+
+    private void dropExpiredUser(String username) {
+        try {
+            // Users created through the shared-role model own nothing and hold no direct grants,
+            // so a plain DROP USER succeeds even for a non-superuser admin.
+            dwhJdbcTemplate.execute(String.format("DROP USER IF EXISTS %s", username)); //NOSONAR
+            log.info("Dropped expired temporary user: {}", username);
+        } catch (DataAccessException e) {
+            // Legacy users (created before the shared-role model) still own objects and/or hold direct
+            // privileges, which PostgreSQL refuses to drop (SQLSTATE 2BP01). Reclaim them and retry.
+            log.warn("Plain drop of expired user {} failed, attempting to reclaim its objects and grants", username, e);
+            reclaimAndDropLegacyUser(username);
+        }
+    }
+
+    /**
+     * Cleanup path for users predating the shared-role model. Their tables are handed over to the admin
+     * (rather than deleted) and their remaining direct grants are removed, so the role can be dropped.
+     * {@code REASSIGN OWNED} / {@code DROP OWNED} require membership in the target role, hence the initial
+     * self-grant - a non-superuser {@code CREATEROLE} admin cannot run them otherwise.
+     */
+    private void reclaimAndDropLegacyUser(String username) {
+        try {
+            dwhJdbcTemplate.execute(String.format("GRANT %s TO CURRENT_USER", username)); //NOSONAR
+            dwhJdbcTemplate.execute(String.format("REASSIGN OWNED BY %s TO CURRENT_USER", username)); //NOSONAR
+            dwhJdbcTemplate.execute(String.format("DROP OWNED BY %s", username)); //NOSONAR
+            dwhJdbcTemplate.execute(String.format("DROP USER IF EXISTS %s", username)); //NOSONAR
+            log.info("Reclaimed and dropped legacy temporary user: {}", username);
+        } catch (DataAccessException e) {
+            // e.g. the role also holds grants in another database of the cluster, which DROP OWNED
+            // cannot reach from here. Log and move on so the rest of the cleanup still runs.
+            log.error("Could not drop expired temporary user {}", username, e);
         }
     }
 
     @Transactional
     public TemporaryUserResponseDto createTemporaryUser() {
+        // Self-healing: make sure the shared role exists even if provisioning at startup could not reach the DWH.
+        ensureSharedRole();
+
         String username = "temp_user_" + UUID.randomUUID().toString().substring(0, 8);
         String password = UUID.randomUUID().toString();
         LocalDateTime expiryDate = LocalDateTime.now().plusDays(hellodataProperties.getTempUserPasswordValidInDays());
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-        String createUserSql = String.format("CREATE USER %s WITH PASSWORD '%s' VALID UNTIL '%s'", username, password, expiryDate.format(formatter));
+        String createUserSql = String.format("CREATE USER %s WITH PASSWORD '%s' VALID UNTIL '%s'", username, password, expiryDate.format(TIMESTAMP_FORMATTER));
         dwhJdbcTemplate.execute(createUserSql);
 
+        String sharedRole = hellodataProperties.getDwhSharedRole();
+        // All access flows through the shared role; the user itself receives no direct object privileges.
+        dwhJdbcTemplate.execute(String.format("GRANT %s TO %s", sharedRole, username)); //NOSONAR
+        // Every session of this user runs as the shared role, so objects it creates are owned by the shared
+        // role - shared between all temporary users and never left behind blocking the user's own removal.
+        dwhJdbcTemplate.execute(String.format("ALTER ROLE %s SET role TO %s", username, sharedRole)); //NOSONAR
+
+        log.debug("Created temporary user {} as member of shared role {}", username, sharedRole);
         TemporaryUserResponseDto responseDto = createResponseDto(hellodataProperties.getDwhUrl());
-        String grantAccessSql = String.format("GRANT ALL PRIVILEGES ON DATABASE %s TO %s", responseDto.getDatabaseName(), username);
-        dwhJdbcTemplate.execute(grantAccessSql);
-
-        List<String> dwhTempUserSchemas = hellodataProperties.getDwhTempUserSchemas();
-        for (String schema : dwhTempUserSchemas) {
-            String grantSchemaAccessSql = String.format("GRANT USAGE ON SCHEMA %s TO %s", schema, username);
-            dwhJdbcTemplate.execute(grantSchemaAccessSql);
-
-            String grantAllTablesAccessSql = String.format("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s", schema, username);
-            dwhJdbcTemplate.execute(grantAllTablesAccessSql);
-
-            String grantAllSequencesAccessSql = String.format("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s", schema, username);
-            dwhJdbcTemplate.execute(grantAllSequencesAccessSql);
-        }
-
-        log.debug("Username: {}, Password: {}", username, password);
         responseDto.setPassword(password);
         responseDto.setUsername(username);
         responseDto.setExpiryDate(expiryDate);
         return responseDto;
+    }
+
+    /**
+     * Idempotently provisions the shared group role, its read grants on the modelled schemas and a shared
+     * read-write schema it owns. Safe to call repeatedly; re-running also refreshes the read grants so tables
+     * added to the modelled schemas after the last run become visible to temporary users.
+     */
+    public void ensureSharedRole() {
+        String sharedRole = hellodataProperties.getDwhSharedRole();
+        String sharedSchema = hellodataProperties.getDwhSharedSchema();
+        String databaseName = createResponseDto(hellodataProperties.getDwhUrl()).getDatabaseName();
+
+        // PostgreSQL has no CREATE ROLE IF NOT EXISTS, so guard it.
+        dwhJdbcTemplate.execute(String.format(
+                "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '%s') THEN CREATE ROLE %s NOLOGIN; END IF; END $$;",
+                sharedRole, sharedRole)); //NOSONAR
+
+        // Members must be able to connect to the DWH.
+        dwhJdbcTemplate.execute(String.format("GRANT CONNECT ON DATABASE %s TO %s", databaseName, sharedRole)); //NOSONAR
+
+        // Read-only access to the modelled schemas.
+        for (String schema : hellodataProperties.getDwhTempUserSchemas()) {
+            dwhJdbcTemplate.execute(String.format("GRANT USAGE ON SCHEMA %s TO %s", schema, sharedRole)); //NOSONAR
+            dwhJdbcTemplate.execute(String.format("GRANT SELECT ON ALL TABLES IN SCHEMA %s TO %s", schema, sharedRole)); //NOSONAR
+            dwhJdbcTemplate.execute(String.format("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA %s TO %s", schema, sharedRole)); //NOSONAR
+        }
+
+        // Shared read-write workspace; objects created here are owned by the shared role (users run as it).
+        dwhJdbcTemplate.execute(String.format("CREATE SCHEMA IF NOT EXISTS %s", sharedSchema)); //NOSONAR
+        dwhJdbcTemplate.execute(String.format("GRANT USAGE, CREATE ON SCHEMA %s TO %s", sharedSchema, sharedRole)); //NOSONAR
     }
 
     private TemporaryUserResponseDto createResponseDto(String jdbcUrl) {

--- a/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/resources/application.yaml
+++ b/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/main/resources/application.yaml
@@ -44,6 +44,11 @@ hello-data:
       - public
       - lzn
       - csv
+    # Shared group role that owns temporary users' objects and holds their privileges.
+    # PostgreSQL roles are cluster-global: in a cluster shared by several data domains, override this
+    # per data domain (e.g. include the DWH database name) so the roles do not collide.
+    dwh-shared-role: hd_jupyter_users
+    dwh-shared-schema: jupyter_shared
 spring:
   application:
     name: HelloDATA Sidecar for Jupyterhub

--- a/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/test/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/TemporaryUserServiceSharedRoleTest.java
+++ b/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/test/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/TemporaryUserServiceSharedRoleTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2024, Kanton Bern
+ * All rights reserved.
+ */
+package ch.bedag.dap.hellodata.jupyterhub.sidecar.service.user;
+
+import ch.bedag.dap.hellodata.jupyterhub.sidecar.config.props.HellodataJupyterhubProperties;
+import ch.bedag.dap.hellodata.jupyterhub.sidecar.service.user.dto.TemporaryUserResponseDto;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for the shared-role temporary-user lifecycle against a real PostgreSQL.
+ * <p>
+ * The DWH admin here is a non-superuser {@code CREATEROLE} role that owns the database, mirroring the real
+ * deployment's {@code *_u_owner} role - not the superuser that {@code docker-compose} and a default
+ * Testcontainers setup would hand you. That distinction is the whole point: privilege-sensitive statements
+ * (DROP USER of an object owner, REASSIGN/DROP OWNED) behave differently for a non-superuser, and this test
+ * exercises exactly those. Postgres 15 matches the cluster the fix targets. Requires Docker.
+ */
+class TemporaryUserServiceSharedRoleTest {
+
+    private static final String SHARED_ROLE = "hd_jupyter_users";
+    private static final String SHARED_SCHEMA = "jupyter_shared";
+    private static final String MODELED_SCHEMA = "modeled";
+    private static final String ADMIN_USER = "dwh_owner";
+    private static final String ADMIN_PASSWORD = "dwh_owner";
+
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:15")
+            .withDatabaseName("testdwh")
+            .withUsername("superuser")
+            .withPassword("superuser");
+
+    static {
+        POSTGRES.start();
+    }
+
+    private JdbcTemplate adminJdbc;
+    private TemporaryUserService temporaryUserService;
+
+    @BeforeAll
+    static void bootstrapNonSuperuserAdmin() {
+        JdbcTemplate superuser = jdbc(POSTGRES.getUsername(), POSTGRES.getPassword());
+        superuser.execute("DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '" + ADMIN_USER + "') THEN "
+                + "CREATE ROLE " + ADMIN_USER + " WITH LOGIN PASSWORD '" + ADMIN_PASSWORD + "' CREATEROLE NOSUPERUSER; END IF; END $$;");
+        // The admin owns the database, so it may create schemas and grant CONNECT - just like the real *_u_owner role.
+        superuser.execute("ALTER DATABASE " + POSTGRES.getDatabaseName() + " OWNER TO " + ADMIN_USER);
+    }
+
+    @BeforeEach
+    void setUp() {
+        adminJdbc = jdbc(ADMIN_USER, ADMIN_PASSWORD);
+        resetState();
+
+        // A modelled, read-only schema owned by the admin (stands in for the dbt output schemas).
+        adminJdbc.execute("CREATE SCHEMA " + MODELED_SCHEMA);
+        adminJdbc.execute("CREATE TABLE " + MODELED_SCHEMA + ".fact (id int)");
+
+        HellodataJupyterhubProperties properties = new HellodataJupyterhubProperties();
+        properties.setTempUserPasswordValidInDays(7);
+        properties.setDwhUrl(POSTGRES.getJdbcUrl());
+        properties.setDwhTempUserSchemas(List.of(MODELED_SCHEMA));
+        properties.setDwhSharedRole(SHARED_ROLE);
+        properties.setDwhSharedSchema(SHARED_SCHEMA);
+
+        temporaryUserService = new TemporaryUserService(adminJdbc, properties);
+        temporaryUserService.ensureSharedRole();
+    }
+
+    @Test
+    void ensureSharedRole_isIdempotent() {
+        assertDoesNotThrow(() -> temporaryUserService.ensureSharedRole());
+        assertTrue(roleExists(SHARED_ROLE));
+        assertTrue(schemaExists(SHARED_SCHEMA));
+    }
+
+    @Test
+    void createTemporaryUser_makesMemberOfSharedRole_owningNothing() {
+        TemporaryUserResponseDto user = temporaryUserService.createTemporaryUser();
+
+        assertTrue(roleExists(user.getUsername()));
+        assertTrue(isMember(user.getUsername(), SHARED_ROLE), "temp user must be a member of the shared role");
+        assertEquals(0L, objectsOwnedBy(user.getUsername()), "temp user must own no objects");
+    }
+
+    @Test
+    void sharedOwnership_letsOneUserManageAnotherUsersTables() {
+        TemporaryUserResponseDto userA = temporaryUserService.createTemporaryUser();
+        TemporaryUserResponseDto userB = temporaryUserService.createTemporaryUser();
+
+        // User A creates a table; because its session runs as the shared role, the shared role owns it.
+        jdbc(userA.getUsername(), userA.getPassword()).execute("CREATE TABLE " + SHARED_SCHEMA + ".from_a (id int)");
+        assertEquals(SHARED_ROLE, ownerOf(SHARED_SCHEMA, "from_a"));
+
+        // User B - a different temp user - can drop it, since both act as the owning shared role.
+        assertDoesNotThrow(() -> jdbc(userB.getUsername(), userB.getPassword()).execute("DROP TABLE " + SHARED_SCHEMA + ".from_a"));
+        assertFalse(tableExists(SHARED_SCHEMA, "from_a"));
+    }
+
+    @Test
+    void cleanupExpiredUsers_dropsExpiredUser_butKeepsSharedTables() {
+        TemporaryUserResponseDto user = temporaryUserService.createTemporaryUser();
+        jdbc(user.getUsername(), user.getPassword()).execute("CREATE TABLE " + SHARED_SCHEMA + ".keep_me (id int)");
+        expire(user.getUsername());
+
+        assertDoesNotThrow(() -> temporaryUserService.cleanupExpiredUsers());
+
+        assertFalse(roleExists(user.getUsername()), "expired user should be dropped");
+        assertTrue(tableExists(SHARED_SCHEMA, "keep_me"), "tables owned by the shared role must survive");
+        assertEquals(SHARED_ROLE, ownerOf(SHARED_SCHEMA, "keep_me"));
+    }
+
+    @Test
+    void cleanupExpiredUsers_keepsActiveUser() {
+        TemporaryUserResponseDto user = temporaryUserService.createTemporaryUser();
+
+        temporaryUserService.cleanupExpiredUsers();
+
+        assertTrue(roleExists(user.getUsername()), "a non-expired user must not be touched");
+    }
+
+    @Test
+    void cleanupExpiredUsers_reclaimsLegacyUser_preservingItsTable() {
+        // A user in the pre-shared-role shape: expired, holds direct grants, and owns a table.
+        adminJdbc.execute("CREATE USER temp_user_legacy01 WITH PASSWORD 'legacy' VALID UNTIL '2000-01-01'");
+        adminJdbc.execute("GRANT USAGE ON SCHEMA " + MODELED_SCHEMA + " TO temp_user_legacy01");
+        adminJdbc.execute("GRANT SELECT ON ALL TABLES IN SCHEMA " + MODELED_SCHEMA + " TO temp_user_legacy01");
+        adminJdbc.execute("CREATE TABLE " + SHARED_SCHEMA + ".legacy_output (id int)");
+        adminJdbc.execute("GRANT temp_user_legacy01 TO CURRENT_USER");
+        // PostgreSQL requires the new owner to hold CREATE on the schema before it can own the table.
+        adminJdbc.execute("GRANT USAGE, CREATE ON SCHEMA " + SHARED_SCHEMA + " TO temp_user_legacy01");
+        adminJdbc.execute("ALTER TABLE " + SHARED_SCHEMA + ".legacy_output OWNER TO temp_user_legacy01");
+
+        assertDoesNotThrow(() -> temporaryUserService.cleanupExpiredUsers());
+
+        assertFalse(roleExists("temp_user_legacy01"), "legacy user must be reclaimed and dropped");
+        assertTrue(tableExists(SHARED_SCHEMA, "legacy_output"), "its table must be handed over, not deleted");
+        assertEquals(ADMIN_USER, ownerOf(SHARED_SCHEMA, "legacy_output"), "table should be reassigned to the admin");
+    }
+
+    // --- helpers -------------------------------------------------------------------------------------------
+
+    private void resetState() {
+        for (String username : adminJdbc.queryForList(
+                "SELECT rolname FROM pg_roles WHERE rolname LIKE 'temp_user_%'", String.class)) {
+            reclaimAndDropSilently(username);
+        }
+        silently("DROP SCHEMA IF EXISTS " + SHARED_SCHEMA + " CASCADE");
+        silently("DROP SCHEMA IF EXISTS " + MODELED_SCHEMA + " CASCADE");
+        if (roleExists(SHARED_ROLE)) {
+            silently("GRANT " + SHARED_ROLE + " TO CURRENT_USER");
+            silently("REASSIGN OWNED BY " + SHARED_ROLE + " TO CURRENT_USER");
+            silently("DROP OWNED BY " + SHARED_ROLE);
+            silently("DROP ROLE IF EXISTS " + SHARED_ROLE);
+        }
+    }
+
+    private void reclaimAndDropSilently(String username) {
+        silently("GRANT " + username + " TO CURRENT_USER");
+        silently("REASSIGN OWNED BY " + username + " TO CURRENT_USER");
+        silently("DROP OWNED BY " + username);
+        silently("DROP USER IF EXISTS " + username);
+    }
+
+    private void silently(String sql) {
+        try {
+            adminJdbc.execute(sql);
+        } catch (RuntimeException ignored) {
+            // best-effort teardown between tests
+        }
+    }
+
+    private void expire(String username) {
+        adminJdbc.execute("ALTER USER " + username + " VALID UNTIL '2000-01-01'");
+    }
+
+    private boolean roleExists(String role) {
+        Long count = adminJdbc.queryForObject("SELECT count(*) FROM pg_roles WHERE rolname = ?", Long.class, role);
+        return count != null && count > 0;
+    }
+
+    private boolean schemaExists(String schema) {
+        // Query the catalog, not information_schema, which is filtered to the current role's privileges.
+        Long count = adminJdbc.queryForObject(
+                "SELECT count(*) FROM pg_namespace WHERE nspname = ?", Long.class, schema);
+        return count != null && count > 0;
+    }
+
+    private boolean tableExists(String schema, String table) {
+        // pg_class is visible regardless of privileges; information_schema.tables is not (the admin is not a
+        // member of the shared role that owns these tables, so it would not see them there).
+        Long count = adminJdbc.queryForObject(
+                "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+                        + "WHERE n.nspname = ? AND c.relname = ? AND c.relkind = 'r'",
+                Long.class, schema, table);
+        return count != null && count > 0;
+    }
+
+    private boolean isMember(String member, String group) {
+        return Boolean.TRUE.equals(adminJdbc.queryForObject("SELECT pg_has_role(?, ?, 'member')", Boolean.class, member, group));
+    }
+
+    private long objectsOwnedBy(String role) {
+        Long count = adminJdbc.queryForObject(
+                "SELECT count(*) FROM pg_class c JOIN pg_roles r ON r.oid = c.relowner WHERE r.rolname = ?", Long.class, role);
+        return count == null ? 0 : count;
+    }
+
+    private String ownerOf(String schema, String table) {
+        return adminJdbc.queryForObject(
+                "SELECT r.rolname FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+                        + "JOIN pg_roles r ON r.oid = c.relowner WHERE n.nspname = ? AND c.relname = ?",
+                String.class, schema, table);
+    }
+
+    private static JdbcTemplate jdbc(String username, String password) {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(POSTGRES.getJdbcUrl());
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        return new JdbcTemplate(dataSource);
+    }
+}

--- a/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/test/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/TemporaryUserServiceTest.java
+++ b/hello-data-sidecars/hello-data-sidecar-jupyterhub/src/test/java/ch/bedag/dap/hellodata/jupyterhub/sidecar/service/user/TemporaryUserServiceTest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class TemporaryUserServiceTest {
 
+    private static final String SHARED_ROLE = "hd_jupyter_users";
+    private static final String SHARED_SCHEMA = "jupyter_shared";
+
     @Mock
     private HellodataJupyterhubProperties hellodataProperties;
 
@@ -28,51 +31,64 @@ class TemporaryUserServiceTest {
     @InjectMocks
     private TemporaryUserService temporaryUserService;
 
-    private int tempUserPasswordValidInDays;
-    private String dwhUrl;
     private List<String> dwhTempUserSchemas;
 
     @BeforeEach
     void setUp() {
-        tempUserPasswordValidInDays = 7;
-        dwhUrl = "jdbc:testDatabaseUrl";
         dwhTempUserSchemas = List.of("schema1", "schema2");
 
-        when(hellodataProperties.getTempUserPasswordValidInDays()).thenReturn(tempUserPasswordValidInDays);
-        when(hellodataProperties.getDwhUrl()).thenReturn(dwhUrl);
+        when(hellodataProperties.getTempUserPasswordValidInDays()).thenReturn(7);
+        when(hellodataProperties.getDwhUrl()).thenReturn("jdbc:postgresql://localhost:5432/testdwh");
         when(hellodataProperties.getDwhTempUserSchemas()).thenReturn(dwhTempUserSchemas);
+        when(hellodataProperties.getDwhSharedRole()).thenReturn(SHARED_ROLE);
+        when(hellodataProperties.getDwhSharedSchema()).thenReturn(SHARED_SCHEMA);
     }
 
     @Test
-    void createTemporaryUser_ShouldCreateUserAndGrantAccess() {
-        // given when
+    void createTemporaryUser_ShouldCreateUserAsMemberOfSharedRole() {
         TemporaryUserResponseDto responseDto = temporaryUserService.createTemporaryUser();
 
-        // then
         assertNotNull(responseDto);
         assertNotNull(responseDto.getUsername());
         assertNotNull(responseDto.getPassword());
         assertNotNull(responseDto.getExpiryDate());
-
-        String expectedUsernamePattern = "temp_user_\\w{8}";
-        assertTrue(responseDto.getUsername().matches(expectedUsernamePattern));
+        assertTrue(responseDto.getUsername().matches("temp_user_\\w{8}"));
         assertFalse(responseDto.getPassword().isEmpty());
 
+        String username = responseDto.getUsername();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String formattedExpiryDate = responseDto.getExpiryDate().format(formatter);
 
-        verify(dwhJdbcTemplate).execute(startsWith("CREATE USER " + responseDto.getUsername()));
+        // user is created with an expiring password
+        verify(dwhJdbcTemplate).execute(startsWith("CREATE USER " + username));
         verify(dwhJdbcTemplate).execute(contains("VALID UNTIL '" + formattedExpiryDate + "'"));
 
-        // verify granting privileges on database
-        verify(dwhJdbcTemplate).execute(contains("GRANT ALL PRIVILEGES ON DATABASE " + responseDto.getDatabaseName()));
+        // access flows through the shared role, and the user runs each session as it
+        verify(dwhJdbcTemplate).execute("GRANT " + SHARED_ROLE + " TO " + username);
+        verify(dwhJdbcTemplate).execute("ALTER ROLE " + username + " SET role TO " + SHARED_ROLE);
 
-        // verify schema access grants
+        // the user itself receives no direct object privileges - everything is on the shared role
+        verify(dwhJdbcTemplate, never()).execute(contains("GRANT ALL PRIVILEGES ON DATABASE testdwh TO " + username));
+        verify(dwhJdbcTemplate, never()).execute(contains("ON ALL TABLES IN SCHEMA schema1 TO " + username));
+    }
+
+    @Test
+    void createTemporaryUser_ShouldEnsureSharedRoleAndReadGrants() {
+        temporaryUserService.createTemporaryUser();
+
+        // shared role provisioned idempotently
+        verify(dwhJdbcTemplate).execute(contains("CREATE ROLE " + SHARED_ROLE + " NOLOGIN"));
+        verify(dwhJdbcTemplate).execute("GRANT CONNECT ON DATABASE testdwh TO " + SHARED_ROLE);
+
+        // read-only grants on the modelled schemas go to the shared role, not the user
         for (String schema : dwhTempUserSchemas) {
-            verify(dwhJdbcTemplate).execute(contains("GRANT USAGE ON SCHEMA " + schema));
-            verify(dwhJdbcTemplate).execute(contains("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA " + schema));
-            verify(dwhJdbcTemplate).execute(contains("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA " + schema));
+            verify(dwhJdbcTemplate).execute("GRANT USAGE ON SCHEMA " + schema + " TO " + SHARED_ROLE);
+            verify(dwhJdbcTemplate).execute("GRANT SELECT ON ALL TABLES IN SCHEMA " + schema + " TO " + SHARED_ROLE);
+            verify(dwhJdbcTemplate).execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA " + schema + " TO " + SHARED_ROLE);
         }
 
+        // shared read-write workspace owned via the shared role
+        verify(dwhJdbcTemplate).execute("CREATE SCHEMA IF NOT EXISTS " + SHARED_SCHEMA);
+        verify(dwhJdbcTemplate).execute("GRANT USAGE, CREATE ON SCHEMA " + SHARED_SCHEMA + " TO " + SHARED_ROLE);
     }
 }


### PR DESCRIPTION
## Problem

Temporary DWH users handed to JupyterHub notebooks were never removed. `cleanupExpiredUsers()` ran `DROP USER`, but PostgreSQL refuses to drop a role that still holds privileges or owns objects (SQLSTATE `2BP01`), so the nightly job aborted on the first expired user and the roles piled up. Verified against a real environment: **55** expired `temp_user_*` roles in a single namespace, the oldest from 2024. Their passwords expire via `VALID UNTIL`, so this is not open access, but the roles and their privileges accumulate indefinitely.

This builds on the diagnosis reported in #483 by @carranza-javier (credited as co-author). While verifying, we found the sidecar's DWH admin is a **non-superuser `CREATEROLE`** role, for which the `REASSIGN OWNED` / `DROP OWNED` approach is permission-denied unless the admin first grants itself membership in the target role - so we take a slightly broader approach here.

## Solution

Model access through a **shared group role**:

- Each temporary user is only a login credential that is a **member of the shared role** and runs every session as it (`ALTER ROLE … SET role`).
- All privileges and everything a user creates therefore belong to the shared role, so:
  - an expired user owns nothing and holds no direct grants → a **plain `DROP USER` succeeds**, even for the non-superuser admin;
  - notebook users (all admins) **share one workspace** and can manage each other's tables.
- The shared role, its read grants on the modelled schemas and a group-owned read-write schema are provisioned **idempotently at startup** (`DwhSharedRoleInitializer`) and re-ensured on first user creation.
- `cleanupExpiredUsers()` is no longer `@Transactional` and keeps a **reclaim path** (`GRANT self → REASSIGN OWNED → DROP OWNED → DROP USER`) that self-heals pre-existing legacy users, handing their tables to the admin instead of deleting them.

## Notes

- Privileges are tightened to least-privilege: `SELECT` on the modelled schemas, read-write only in the group-owned shared schema. If notebooks currently rely on writing into the dbt schemas, that is an intentional behaviour change to flag.
- `dwh-shared-role` must be unique per data domain in a shared PostgreSQL cluster (roles are cluster-global).
- The existing 55 orphans are reclaimed on the next nightly run per data domain once this is deployed.

## Testing

- `TemporaryUserServiceTest` - updated mock-based unit test for the new create path.
- `TemporaryUserServiceSharedRoleTest` - Testcontainers test on **PostgreSQL 15** with a **non-superuser admin** (mirroring the real `*_u_owner` role), covering idempotent provisioning, membership/owns-nothing, cross-user table management, cleanup preserving shared tables, active-user retention, and legacy-user reclaim.

`./mvnw -pl hello-data-sidecars/hello-data-sidecar-jupyterhub test` → 10/10 green (Docker required for the Testcontainers test).
