### PR TITLE
HELLODATA-4099 fix(portal-ui): harden auth against inactivity - focus…

### DIFF
--- a/hello-data-portal/hello-data-portal-ui/src/app/app.component.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/app.component.ts
@@ -26,7 +26,7 @@
 ///
 
 import {Component, HostBinding, inject, OnDestroy, OnInit} from '@angular/core';
-import {AppInfoService, ScreenService} from './shared/services';
+import {AppInfoService, ScreenService, SessionRenewalService} from './shared/services';
 import {Store} from "@ngrx/store";
 import {AppState} from "./store/app/app.state";
 import {selectCurrentBusinessDomain, selectFirstLogin} from "./store/auth/auth.selector";
@@ -51,6 +51,7 @@ export class AppComponent implements OnInit, OnDestroy {
   private readonly screen = inject(ScreenService);
   appInfo = inject(AppInfoService);
   private readonly title = inject(Title);
+  private readonly sessionRenewal = inject(SessionRenewalService);
   private readonly destroy$ = new Subject<void>();
 
   private static readonly REDIRECT_TO_PARAM = 'redirectTo';
@@ -92,6 +93,11 @@ export class AppComponent implements OnInit, OnDestroy {
     if (!window.location.pathname.includes('/callback')) {
       this.store.dispatch(checkAuth());
     }
+
+    // Refresh the token when the tab regains focus, so a session that idled in the
+    // background (silent-renew timer throttled while hidden) recovers silently
+    // instead of 401-ing and bouncing the user out of a subsystem iframe.
+    this.sessionRenewal.start();
 
     // Handle redirectTo param stored in sessionStorage (for opening new tab links)
     setTimeout(() => {
@@ -144,11 +150,19 @@ export class AppComponent implements OnInit, OnDestroy {
     const FAST_INTERVAL_MS = 5000;
     const FAST_PHASE_MS = 120000;
 
-    // Start the normal 30s polling immediately
-    let profileTimer = setInterval(() => {
+    // Skip polling while the tab is hidden: the token may be stale (silent-renew is
+    // throttled in the background), so a poll would 401 and trigger a redirect. On
+    // return, SessionRenewalService refreshes first and polling resumes.
+    const dispatchCheckProfile = () => {
+      if (typeof document !== 'undefined' && document.hidden) {
+        return;
+      }
       console.debug("Check profile");
       this.store.dispatch(checkProfile());
-    }, NORMAL_INTERVAL_MS);
+    };
+
+    // Start the normal 30s polling immediately
+    let profileTimer = setInterval(dispatchCheckProfile, NORMAL_INTERVAL_MS);
 
     // If first login, temporarily switch to fast 5s polling, then revert to 30s
     this.store.select(selectFirstLogin).pipe(
@@ -159,17 +173,11 @@ export class AppComponent implements OnInit, OnDestroy {
       console.debug('[App] First login detected, switching to fast profile polling');
       clearInterval(profileTimer);
 
-      const fastTimer = setInterval(() => {
-        console.debug("Check profile (fast)");
-        this.store.dispatch(checkProfile());
-      }, FAST_INTERVAL_MS);
+      const fastTimer = setInterval(dispatchCheckProfile, FAST_INTERVAL_MS);
 
       setTimeout(() => {
         clearInterval(fastTimer);
-        profileTimer = setInterval(() => {
-          console.debug("Check profile");
-          this.store.dispatch(checkProfile());
-        }, NORMAL_INTERVAL_MS);
+        profileTimer = setInterval(dispatchCheckProfile, NORMAL_INTERVAL_MS);
       }, FAST_PHASE_MS);
     });
   }

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/interceptor/token-interceptor.service.spec.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/interceptor/token-interceptor.service.spec.ts
@@ -29,7 +29,7 @@ import {TestBed} from '@angular/core/testing';
 import {HTTP_INTERCEPTORS, HttpClient, HttpErrorResponse} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
 import {LoginResponse, OidcSecurityService} from 'angular-auth-oidc-client';
-import {of, throwError} from 'rxjs';
+import {of, Subject, throwError} from 'rxjs';
 import {beforeAll, describe, expect, it, jest} from '@jest/globals';
 import {TokenInterceptor} from './token-interceptor.service';
 import {AuthService} from '../services';
@@ -65,8 +65,9 @@ describe('TokenInterceptor', () => {
       logoffLocal: jest.fn()
     };
 
-    const routerMock = {
-      navigate: jest.fn()
+    const routerMock: { navigate: jest.Mock; url: string } = {
+      navigate: jest.fn(),
+      url: '/'
     };
 
     TestBed.configureTestingModule({
@@ -208,6 +209,78 @@ describe('TokenInterceptor', () => {
             try {
               expect(oidcMock.forceRefreshSession).toHaveBeenCalled();
               expect(oidcMock.logoffLocal).toHaveBeenCalled();
+              expect(routerMock.navigate).toHaveBeenCalledWith(['/home']);
+              httpMock.verify();
+              done();
+            } catch (e) {
+              done(e as Error);
+            }
+          }, 0);
+        }
+      });
+
+      const req = httpMock.expectOne(testUrl);
+      req.flush({message: 'Unauthorized'}, {status: 401, statusText: 'Unauthorized'});
+    });
+
+    it('should refresh only once for concurrent 401s and retry both (single-flight)', (done) => {
+      const {oidcMock, httpClient, httpMock} = setupTestBed(newMockToken);
+
+      // Deferred refresh so the second 401 arrives while the first is still refreshing.
+      const refresh$ = new Subject<LoginResponse>();
+      oidcMock.forceRefreshSession.mockReturnValue(refresh$.asObservable());
+
+      let completed = 0;
+      const onNext = () => {
+        if (++completed === 2) {
+          try {
+            // The core race fix: a single forceRefreshSession() for the whole burst.
+            expect(oidcMock.forceRefreshSession).toHaveBeenCalledTimes(1);
+            httpMock.verify();
+            done();
+          } catch (e) {
+            done(e as Error);
+          }
+        }
+      };
+
+      httpClient.get(testUrl).subscribe({next: onNext, error: (e) => done(e as Error)});
+      httpClient.get(testUrl).subscribe({next: onNext, error: (e) => done(e as Error)});
+
+      // Both initial requests fail with 401 while the (single) refresh is in flight.
+      const initial = httpMock.match(testUrl);
+      expect(initial.length).toBe(2);
+      initial.forEach(r => r.flush({message: 'Unauthorized'}, {status: 401, statusText: 'Unauthorized'}));
+
+      // Release the one in-flight refresh; both parked requests should now retry.
+      refresh$.next({isAuthenticated: true} as LoginResponse);
+      refresh$.complete();
+
+      const retries = httpMock.match(testUrl);
+      expect(retries.length).toBe(2);
+      retries.forEach(r => {
+        expect(r.request.headers.get('Authorization')).toBe(`Bearer ${newMockToken}`);
+        r.flush({success: true});
+      });
+    });
+
+    it('should remember the current route so the user returns after re-auth', (done) => {
+      sessionStorage.clear();
+      const {routerMock, oidcMock, httpClient, httpMock} = setupTestBed(mockToken);
+      routerMock.url = '/orchestration';
+
+      oidcMock.forceRefreshSession.mockReturnValue(
+        of({isAuthenticated: false} as LoginResponse)
+      );
+
+      httpClient.get(testUrl).subscribe({
+        next: () => done(new Error('Should have errored')),
+        error: () => {
+          setTimeout(() => {
+            try {
+              // Route is saved (slash-less) for AppComponent's post-login restore,
+              // instead of always dropping the user on /home.
+              expect(sessionStorage.getItem('redirectTo')).toBe('orchestration');
               expect(routerMock.navigate).toHaveBeenCalledWith(['/home']);
               httpMock.verify();
               done();

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/interceptor/token-interceptor.service.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/interceptor/token-interceptor.service.ts
@@ -47,9 +47,13 @@ export class TokenInterceptor implements HttpInterceptor {
   private readonly oidcSecurityService = inject(OidcSecurityService);
   private readonly router = inject(Router);
 
+  private static readonly REDIRECT_TO_KEY = 'redirectTo';
+
   private isRefreshing = false;
   private isRedirectingToLogin = false;
-  private readonly refreshTokenSubject: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
+  // Not readonly: on a failed refresh we replace the (now errored) subject with a
+  // fresh one so subsequent refresh cycles can reuse it (see handle401Error).
+  private refreshTokenSubject: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
 
   intercept(
     req: HttpRequest<any>,
@@ -106,50 +110,58 @@ export class TokenInterceptor implements HttpInterceptor {
 
   private handle401Error(req: HttpRequest<any>, next: HttpHandler, originalError: HttpErrorResponse): Observable<HttpEvent<any>> {
     if (this.isRefreshing) {
-      // Another request is already refreshing the token, wait for it
+      // Another request is already refreshing the token, wait for it to broadcast
+      // the new token (or to error, so we don't hang here forever - "Waiting for...").
       console.debug('[TokenInterceptor] Waiting for ongoing token refresh');
       return this.refreshTokenSubject.pipe(
         filter(token => token !== null),
         take(1),
         switchMap(token => next.handle(this.addTokenToRequest(req, token)))
       );
-    } else {
-      this.isRefreshing = true;
-      this.refreshTokenSubject.next(null);
-
-      console.debug('[TokenInterceptor] Attempting token refresh for request:', req.url);
-
-      // Try to refresh the token using OIDC library
-      return this.oidcSecurityService.forceRefreshSession().pipe(
-        switchMap((result) => {
-          this.isRefreshing = false;
-          console.debug('[TokenInterceptor] Token refresh result:', result?.isAuthenticated ? 'authenticated' : 'not authenticated');
-
-          if (result?.isAuthenticated) {
-            // Token refresh successful, get new token and retry request
-            return this.authService.accessToken.pipe(
-              take(1),
-              switchMap(newToken => {
-                console.debug('[TokenInterceptor] Retrying request with new token');
-                this.refreshTokenSubject.next(newToken);
-                return next.handle(this.addTokenToRequest(req, newToken));
-              })
-            );
-          } else {
-            // Refresh failed, redirect to login
-            console.warn('[TokenInterceptor] Token refresh failed (not authenticated), redirecting to login. Original URL:', req.url);
-            this.redirectToLogin();
-            return throwError(() => originalError);
-          }
-        }),
-        catchError((refreshError) => {
-          this.isRefreshing = false;
-          console.warn('[TokenInterceptor] Token refresh error, redirecting to login. Error:', refreshError, 'Original URL:', req.url);
-          this.redirectToLogin();
-          return throwError(() => originalError);
-        })
-      );
     }
+
+    this.isRefreshing = true;
+    // Capture the subject this refresh cycle owns. On failure we error THIS instance
+    // to unblock parked requests, then swap in a fresh one for future cycles.
+    const cycleSubject = this.refreshTokenSubject;
+    cycleSubject.next(null);
+
+    console.debug('[TokenInterceptor] Attempting token refresh for request:', req.url);
+
+    // Try to refresh the token using OIDC library
+    return this.oidcSecurityService.forceRefreshSession().pipe(
+      switchMap((result) => {
+        console.debug('[TokenInterceptor] Token refresh result:', result?.isAuthenticated ? 'authenticated' : 'not authenticated');
+        if (result?.isAuthenticated) {
+          return this.authService.accessToken.pipe(take(1));
+        }
+        // Refresh returned "not authenticated" - treat as a refresh failure below.
+        return throwError(() => originalError);
+      }),
+      // Refresh-failure boundary. Placed BEFORE the retry switchMap so that a failure
+      // of the *retried* request (a fresh 401/500 after a SUCCESSFUL refresh) is NOT
+      // mistaken for a refresh failure and does not trigger a spurious logout.
+      catchError((refreshError) => {
+        console.warn('[TokenInterceptor] Token refresh error, redirecting to login. Error:', refreshError, 'Original URL:', req.url);
+        this.isRefreshing = false;
+        // Unblock any requests parked on this cycle's subject so they error out
+        // instead of hanging forever, then replace the (now dead) errored subject.
+        this.refreshTokenSubject = new BehaviorSubject<string | null>(null);
+        cycleSubject.error(refreshError ?? originalError);
+        this.redirectToLogin();
+        return throwError(() => originalError);
+      }),
+      switchMap((newToken: string | null) => {
+        console.debug('[TokenInterceptor] Retrying request with new token');
+        // Broadcast the new token to parked requests FIRST, then clear the flag.
+        // Resetting isRefreshing only after the broadcast closes the race window where
+        // a 401 arriving mid-refresh would start a SECOND forceRefreshSession() and be
+        // rejected by Keycloak's rotating refresh token, forcing a logout.
+        cycleSubject.next(newToken);
+        this.isRefreshing = false;
+        return next.handle(this.addTokenToRequest(req, newToken));
+      })
+    );
   }
 
   private addTokenToRequest(req: HttpRequest<any>, token: string | null): HttpRequest<any> {
@@ -168,6 +180,13 @@ export class TokenInterceptor implements HttpInterceptor {
       return; // Prevent multiple concurrent login redirects
     }
     this.isRedirectingToLogin = true;
+    // Remember where the user was so we can bring them back after re-authentication,
+    // instead of always dumping them on /home. Without this, a token expiry while the
+    // user sits in a subsystem iframe (CloudBeaver / Airflow / Superset) kicks them out
+    // to the portal home page. The AppComponent restores this from sessionStorage once
+    // auth completes. Note: only the Angular route is preserved, not the subsystem's
+    // internal (cross-origin) iframe location.
+    this.rememberCurrentRouteForRedirect();
     console.warn('[TokenInterceptor] Clearing local auth state and navigating to /home for re-authentication');
     // Clear stale local auth state. The AutoLoginPartialRoutesGuard on /home
     // will trigger the OIDC authorize flow properly.
@@ -177,5 +196,23 @@ export class TokenInterceptor implements HttpInterceptor {
       this.isRedirectingToLogin = false;
       this.router.navigate(['/home']);
     }, 0);
+  }
+
+  private rememberCurrentRouteForRedirect(): void {
+    try {
+      const currentUrl = this.router.url;
+      // Skip routes that would create a redirect loop or aren't worth restoring.
+      if (!currentUrl || currentUrl === '/' || currentUrl.startsWith('/home') || currentUrl.includes('/callback')) {
+        return;
+      }
+      // Strip the leading slash: the AppComponent restore path dispatches
+      // navigate({url}) which router.navigate([url]) accepts either way, and the
+      // existing redirectTo links (menu.state/service) use the slash-less form.
+      const redirectTo = currentUrl.startsWith('/') ? currentUrl.substring(1) : currentUrl;
+      sessionStorage.setItem(TokenInterceptor.REDIRECT_TO_KEY, redirectTo);
+      console.debug('[TokenInterceptor] Saved redirect target for post-login restore:', redirectTo);
+    } catch (e) {
+      console.debug('[TokenInterceptor] Could not persist redirect target', e);
+    }
   }
 }

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/services/cloudbeaver-session.service.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/services/cloudbeaver-session.service.ts
@@ -19,6 +19,11 @@ export class CloudbeaverSessionService {
     this.createTimerCookie();
     this.renewSessionInterval$
       .subscribe(() => {
+        // Skip while the tab is hidden: the token may be stale (silent-renew throttled
+        // in the background) so the call would 401; it resumes once the tab is visible.
+        if (typeof document !== 'undefined' && document.hidden) {
+          return;
+        }
         if (this.cookieExists()) {
           this.store.dispatch(prolongCBSession());
         } else {

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/services/index.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/services/index.ts
@@ -28,3 +28,4 @@
 export * from './app-info.service';
 export * from './auth.service';
 export * from './screen.service';
+export * from './session-renewal.service';

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/services/session-renewal.service.spec.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/services/session-renewal.service.spec.ts
@@ -1,0 +1,97 @@
+///
+/// Copyright © 2024, Kanton Bern
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are met:
+///     * Redistributions of source code must retain the above copyright
+///       notice, this list of conditions and the following disclaimer.
+///     * Redistributions in binary form must reproduce the above copyright
+///       notice, this list of conditions and the following disclaimer in the
+///       documentation and/or other materials provided with the distribution.
+///     * Neither the name of the <organization> nor the
+///       names of its contributors may be used to endorse or promote products
+///       derived from this software without specific prior written permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+/// DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+/// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+/// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+/// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+/// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+/// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+/// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+///
+
+import {TestBed} from '@angular/core/testing';
+import {OidcSecurityService} from 'angular-auth-oidc-client';
+import {of} from 'rxjs';
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
+import {SessionRenewalService} from './session-renewal.service';
+
+describe('SessionRenewalService', () => {
+  const nowSec = () => Math.floor(Date.now() / 1000);
+
+  const setup = (opts: {isAuthenticated?: boolean; exp?: number} = {}) => {
+    const oidcMock = {
+      isAuthenticated: jest.fn().mockReturnValue(of(opts.isAuthenticated ?? true)),
+      getPayloadFromAccessToken: jest.fn().mockReturnValue(of({exp: opts.exp})),
+      forceRefreshSession: jest.fn().mockReturnValue(of({isAuthenticated: true}))
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        SessionRenewalService,
+        {provide: OidcSecurityService, useValue: oidcMock}
+      ]
+    });
+
+    const service = TestBed.inject(SessionRenewalService);
+    service.start();
+    return {service, oidcMock};
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(document, 'visibilityState', {value: 'visible', configurable: true});
+  });
+
+  const fireVisibility = () => document.dispatchEvent(new Event('visibilitychange'));
+
+  it('refreshes when the access token is expired or about to expire', () => {
+    const {oidcMock} = setup({isAuthenticated: true, exp: nowSec() - 10});
+    fireVisibility();
+    expect(oidcMock.forceRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT refresh when the access token is still fresh', () => {
+    const {oidcMock} = setup({isAuthenticated: true, exp: nowSec() + 240});
+    fireVisibility();
+    expect(oidcMock.forceRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refresh when the user is not authenticated', () => {
+    const {oidcMock} = setup({isAuthenticated: false, exp: nowSec() - 10});
+    fireVisibility();
+    expect(oidcMock.getPayloadFromAccessToken).not.toHaveBeenCalled();
+    expect(oidcMock.forceRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT act while the tab is hidden', () => {
+    const {oidcMock} = setup({isAuthenticated: true, exp: nowSec() - 10});
+    Object.defineProperty(document, 'visibilityState', {value: 'hidden', configurable: true});
+    fireVisibility();
+    expect(oidcMock.isAuthenticated).not.toHaveBeenCalled();
+    expect(oidcMock.forceRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it('throttles rapid focus events to a single refresh', () => {
+    const {oidcMock} = setup({isAuthenticated: true, exp: nowSec() - 10});
+    fireVisibility();
+    fireVisibility();
+    fireVisibility();
+    expect(oidcMock.forceRefreshSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hello-data-portal/hello-data-portal-ui/src/app/shared/services/session-renewal.service.ts
+++ b/hello-data-portal/hello-data-portal-ui/src/app/shared/services/session-renewal.service.ts
@@ -1,0 +1,111 @@
+///
+/// Copyright © 2024, Kanton Bern
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without
+/// modification, are permitted provided that the following conditions are met:
+///     * Redistributions of source code must retain the above copyright
+///       notice, this list of conditions and the following disclaimer.
+///     * Redistributions in binary form must reproduce the above copyright
+///       notice, this list of conditions and the following disclaimer in the
+///       documentation and/or other materials provided with the distribution.
+///     * Neither the name of the <organization> nor the
+///       names of its contributors may be used to endorse or promote products
+///       derived from this software without specific prior written permission.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+/// DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+/// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+/// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+/// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+/// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+/// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+/// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+///
+
+import {inject, Injectable, NgZone} from '@angular/core';
+import {OidcSecurityService} from 'angular-auth-oidc-client';
+import {EMPTY, switchMap, take} from 'rxjs';
+
+/**
+ * Proactively refreshes the OIDC access token when the tab regains focus/visibility.
+ *
+ * Browsers throttle (and eventually suspend) timers on backgrounded tabs, so the
+ * angular-auth-oidc-client silent-renew timer - scheduled shortly before the access
+ * token expires - often does not fire while the user is on another tab or app. With
+ * the shipped Keycloak realm the access token lives 5 min but the SSO session stays
+ * alive for 30 min of idle, so a token that expired in the background can still be
+ * refreshed silently once the user returns.
+ *
+ * Renewing here, on focus and BEFORE the periodic pollers (profile / CloudBeaver
+ * session) fire, turns the common "away 5-30 min" case into a silent refresh instead
+ * of a 401 that the interceptor would recover from by redirecting to /home. It does
+ * NOT help once the SSO session itself has expired (away > 30 min) - a full re-login
+ * is unavoidable then; that is a Keycloak ssoSessionIdleTimeout matter, not client.
+ */
+@Injectable({providedIn: 'root'})
+export class SessionRenewalService {
+  private readonly oidcSecurityService = inject(OidcSecurityService);
+  private readonly zone = inject(NgZone);
+
+  // Refresh when the access token expires within this window on focus.
+  private static readonly RENEW_WITHIN_SECONDS = 60;
+  // Guard against hammering the token endpoint when the user flips tabs quickly.
+  private static readonly MIN_INTERVAL_MS = 15000;
+
+  private started = false;
+  private lastAttemptMs = 0;
+
+  start(): void {
+    if (this.started || typeof document === 'undefined') {
+      return;
+    }
+    this.started = true;
+    // These listeners are pure DOM plumbing; keep them out of Angular's zone so an
+    // idle tab-switch doesn't schedule change detection. We re-enter the zone only
+    // when we actually trigger a refresh.
+    this.zone.runOutsideAngular(() => {
+      document.addEventListener('visibilitychange', this.onFocusOrVisible);
+      window.addEventListener('focus', this.onFocusOrVisible);
+    });
+  }
+
+  private readonly onFocusOrVisible = (): void => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+    const now = Date.now();
+    if (now - this.lastAttemptMs < SessionRenewalService.MIN_INTERVAL_MS) {
+      return;
+    }
+    this.lastAttemptMs = now;
+
+    this.oidcSecurityService.isAuthenticated().pipe(
+      take(1),
+      switchMap(isAuthenticated => {
+        // Logged out: let the guard / interceptor drive the (re-)login instead.
+        if (!isAuthenticated) {
+          return EMPTY;
+        }
+        return this.oidcSecurityService.getPayloadFromAccessToken().pipe(take(1));
+      })
+    ).subscribe({
+      next: payload => {
+        const expSeconds: number | undefined = payload?.exp;
+        const secondsLeft = expSeconds ? expSeconds - Math.floor(Date.now() / 1000) : 0;
+        if (secondsLeft > SessionRenewalService.RENEW_WITHIN_SECONDS) {
+          return; // token is still fresh, nothing to do
+        }
+        this.zone.run(() => {
+          this.oidcSecurityService.forceRefreshSession().pipe(take(1)).subscribe({
+            next: result => console.debug('[SessionRenewal] refreshed on focus, authenticated:', result?.isAuthenticated),
+            error: e => console.warn('[SessionRenewal] focus refresh failed (will re-auth on next request):', e)
+          });
+        });
+      },
+      error: e => console.debug('[SessionRenewal] could not evaluate token on focus', e)
+    });
+  };
+}


### PR DESCRIPTION
… token renewal, preserve route, fix 401 refresh race

- SessionRenewalService: refresh the access token on tab focus/visibility when it is near expiry, so a session that idled in a backgrounded tab (silent-renew timer throttled by the browser) recovers silently instead of 401-ing on return.
- Pause the profile and CloudBeaver-session pollers while the tab is hidden so they don't fire against a stale token and trigger a redirect.
- TokenInterceptor: broadcast the refreshed token before clearing isRefreshing (single-flight for concurrent 401s), and error parked requests on refresh failure so they no longer hang; move the failure boundary before the retry so a downstream error on the retried request no longer causes a spurious logout.
- redirectToLogin saves the current route so re-auth returns the user to the subsystem page instead of always /home.